### PR TITLE
Fix a bug where min items is 0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "angular-schema-instantiator",
   "main": ["src/instantiator.js", "src/angular-instantiator.js"],
-  "version": "0.2.1",
+  "version": "0.2.2",
   "homepage": "https://github.com/tomarad/JSON-Schema-Instantiator",
   "authors": [
     "Tom Arad <tom@arad.rocks>"

--- a/src/instantiator.js
+++ b/src/instantiator.js
@@ -71,7 +71,7 @@ function instantiate(schema) {
     } else if (type === 'array') {
       data[name] = [];
       var len = 1;
-      if (obj.minItems) {
+      if (obj.minItems || obj.minItems === 0) {
         len = obj.minItems;
       }
 


### PR DESCRIPTION
When min items is 0, it didn't count it because of a stupid `if` mistake.
