### PR TITLE
Add allOf support (closes #4)

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "angular-schema-instantiator",
   "main": ["src/instantiator.js", "src/angular-instantiator.js"],
-  "version": "0.2.2",
+  "version": "0.3.0",
   "homepage": "https://github.com/tomarad/JSON-Schema-Instantiator",
   "authors": [
     "Tom Arad <tom@arad.rocks>"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "json-schema-instantiator",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "A simple instantiator for json schemas.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A simple instantiator for json schemas.",
   "main": "index.js",
   "scripts": {
-    "test": "grunt test"
+    "test": "mocha tests/tests.js"
   },
   "keywords": [
     "JSON",
@@ -15,8 +15,12 @@
   ],
   "author": "Tom Arad",
   "license": "MIT",
-  "repository" :
-    { "type" : "git",
-      "url" : "https://github.com/tomarad/JSON-Schema-Instantiator"
-    }
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/tomarad/JSON-Schema-Instantiator"
+  },
+  "devDependencies": {
+    "chai": "^3.4.0",
+    "mocha": "^2.3.3"
+  }
 }

--- a/src/instantiator.js
+++ b/src/instantiator.js
@@ -56,17 +56,21 @@ function instantiate(schema) {
     if (!obj) {
       return;
     }
-
+    var i;
     var type = obj.type;
     // We want non-primitives objects (primitive === object w/o properties).
     if (type === 'object' && obj.properties) {
-      data[name] = { };
+      data[name] = data[name] || { };
 
       // Visit each property.
       for (var property in obj.properties) {
         if (obj.properties.hasOwnProperty(property)) {
           visit(obj.properties[property], property, data[name]);
         }
+      }
+    } else if (obj.allOf) {
+      for (i = 0; i < obj.allOf.length; i++) {
+        visit(obj.allOf[i], name, data);
       }
     } else if (type === 'array') {
       data[name] = [];
@@ -76,7 +80,7 @@ function instantiate(schema) {
       }
 
       // Instantiate 'len' items.
-      for (var i = 0; i < len; i++) {
+      for (i = 0; i < len; i++) {
         visit(obj.items, i, data[name]);
       }
 

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -1,0 +1,153 @@
+var expect = require("chai").expect;
+
+var instantiate = require('../src/instantiator').instantiate;
+
+var schema, expected, result;
+
+describe("Primitives", function(){
+
+  it("should instantiate string", function(){
+    schema = {
+      "type": "string"
+    };
+    result = instantiate(schema);
+    expected = "";
+    expect(result).to.deep.equal(expected);
+  });
+
+  it("should instantiate number", function(){
+    schema = {
+      "type": "number"
+    };
+    result = instantiate(schema);
+    expected = 0;
+    expect(result).to.deep.equal(expected);
+  });
+
+  it("should instantiate boolean", function(){
+    schema = {
+      "type": "boolean"
+    };
+    result = instantiate(schema);
+    expected = false;
+    expect(result).to.deep.equal(expected);
+  });
+
+  it("should instantiate null", function(){
+    schema = {
+      "type": "null"
+    };
+    result = instantiate(schema);
+    expected = null;
+    expect(result).to.deep.equal(expected);
+  });
+
+  it("should use default property", function(){
+    schema = {
+      "type": "number",
+      "default": 100
+    };
+    result = instantiate(schema);
+    expected = 100;
+    expect(result).to.deep.equal(expected);
+  });
+});
+
+
+describe("Objects", function(){
+  it("should instantiate object without properties", function(){
+    schema = {
+      "type": "object"
+    };
+    result = instantiate(schema);
+    expected = {};
+    expect(result).to.deep.equal(expected);
+  });
+
+  it("should instantiate object with property", function(){
+    schema = {
+      "type": "object",
+      "properties": {
+        "title": {
+          "type": "string",
+        }
+      }
+    };
+    result = instantiate(schema);
+    expected = {
+      "title": ""
+    };
+    expect(result).to.deep.equal(expected);
+  });
+
+  it("should instantiate object with property with default value", function(){
+    schema = {
+      "type": "object",
+      "properties": {
+        "title": {
+          "type": "string",
+          "default": "Example"
+        }
+      }
+    };
+    result = instantiate(schema);
+    expected = {
+      "title": "Example"
+    };
+    expect(result).to.deep.equal(expected);
+  });
+
+  it("should instantiate object with more than one property", function(){
+    schema = {
+      "type": "object",
+      "properties": {
+        "title": {
+          "type": "string",
+          "default": "Example"
+        },
+        "amount": {
+          "type": "number",
+          "default": 10
+        }
+      }
+    };
+    result = instantiate(schema);
+    expected = {
+      "title": "Example",
+      "amount": 10
+    };
+    expect(result).to.deep.equal(expected);
+  });
+});
+
+describe("AllOf", function(){
+  it("should instantiate schema with allOf", function(){
+    schema = {
+      "allOf": [
+        {
+          "type": "object",
+          "properties": {
+            "title": {
+              "type": "string"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "properties": {
+            "amount": {
+              "type": "number",
+              "default": 1
+            }
+          }
+        }
+      ]
+    };
+    result = instantiate(schema);
+    expected = {
+      "title": "",
+      "amount": 1
+    };
+    expect(result).to.deep.equal(expected);
+  });
+});

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -1,51 +1,51 @@
-var expect = require("chai").expect;
+var expect = require('chai').expect;
 
 var instantiate = require('../src/instantiator').instantiate;
 
 var schema, expected, result;
 
-describe("Primitives", function(){
+describe('Primitives', function() {
 
-  it("should instantiate string", function(){
+  it('should instantiate string', function() {
     schema = {
-      "type": "string"
+      'type': 'string'
     };
     result = instantiate(schema);
     expected = "";
     expect(result).to.deep.equal(expected);
   });
 
-  it("should instantiate number", function(){
+  it('should instantiate number', function() {
     schema = {
-      "type": "number"
+      'type': 'number'
     };
     result = instantiate(schema);
     expected = 0;
     expect(result).to.deep.equal(expected);
   });
 
-  it("should instantiate boolean", function(){
+  it('should instantiate boolean', function() {
     schema = {
-      "type": "boolean"
+      'type': 'boolean'
     };
     result = instantiate(schema);
     expected = false;
     expect(result).to.deep.equal(expected);
   });
 
-  it("should instantiate null", function(){
+  it('should instantiate null', function() {
     schema = {
-      "type": "null"
+      'type': 'null'
     };
     result = instantiate(schema);
     expected = null;
     expect(result).to.deep.equal(expected);
   });
 
-  it("should use default property", function(){
+  it('should use default property', function() {
     schema = {
-      "type": "number",
-      "default": 100
+      'type': 'number',
+      'default': 100
     };
     result = instantiate(schema);
     expected = 100;
@@ -54,90 +54,90 @@ describe("Primitives", function(){
 });
 
 
-describe("Objects", function(){
-  it("should instantiate object without properties", function(){
+describe('Objects', function() {
+  it('should instantiate object without properties', function() {
     schema = {
-      "type": "object"
+      'type': 'object'
     };
     result = instantiate(schema);
     expected = {};
     expect(result).to.deep.equal(expected);
   });
 
-  it("should instantiate object with property", function(){
+  it('should instantiate object with property', function() {
     schema = {
-      "type": "object",
-      "properties": {
-        "title": {
-          "type": "string",
+      'type': 'object',
+      'properties': {
+        'title': {
+          'type': 'string',
         }
       }
     };
     result = instantiate(schema);
     expected = {
-      "title": ""
+      'title': ''
     };
     expect(result).to.deep.equal(expected);
   });
 
-  it("should instantiate object with property with default value", function(){
+  it('should instantiate object with property with default value', function() {
     schema = {
-      "type": "object",
-      "properties": {
-        "title": {
-          "type": "string",
-          "default": "Example"
+      'type': 'object',
+      'properties': {
+        'title': {
+          'type': 'string',
+          'default': 'Example'
         }
       }
     };
     result = instantiate(schema);
     expected = {
-      "title": "Example"
+      'title': 'Example'
     };
     expect(result).to.deep.equal(expected);
   });
 
-  it("should instantiate object with more than one property", function(){
+  it('should instantiate object with more than one property', function() {
     schema = {
-      "type": "object",
-      "properties": {
-        "title": {
-          "type": "string",
-          "default": "Example"
+      'type': 'object',
+      'properties': {
+        'title': {
+          'type': 'string',
+          'default': 'Example'
         },
-        "amount": {
-          "type": "number",
-          "default": 10
+        'amount': {
+          'type': 'number',
+          'default': 10
         }
       }
     };
     result = instantiate(schema);
     expected = {
-      "title": "Example",
-      "amount": 10
+      'title': 'Example',
+      'amount': 10
     };
     expect(result).to.deep.equal(expected);
   });
 });
 
-describe("AllOf", function(){
-  it("should instantiate schema with allOf", function(){
+describe('AllOf', function() {
+  it('should instantiate schema with allOf', function() {
     schema = {
-      "allOf": [
+      'allOf': [
         {
-          "type": "object",
-          "properties": {
-            "title": {
-              "type": "string"
+          'type': 'object',
+          'properties': {
+            'title': {
+              'type': 'string'
             }
           }
         },
         {
-          "type": "object",
-          "properties": {
-            "amount": {
-              "type": "number",
-              "default": 1
+          'type': 'object',
+          'properties': {
+            'amount': {
+              'type': 'number',
+              'default': 1
             }
           }
         }
@@ -145,8 +145,8 @@ describe("AllOf", function(){
     };
     result = instantiate(schema);
     expected = {
-      "title": "",
-      "amount": 1
+      'title': '',
+      'amount': 1
     };
     expect(result).to.deep.equal(expected);
   });


### PR DESCRIPTION
Added support of `allOf` keyword.
Your `package.json` contained `test` script: `grunt test`, but there was neither gruntfile nor tests in your repo. So I've added also some basic tests.
