### PR TITLE
feat: support custom global defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,20 +32,47 @@ var schema = {
         },
         "description": {
             "type": "string"
+        },
+        "quantity": {
+            "type": "number"
+        },
+        "endDate": {
+            "type": "string",
+            "format": "date"
         }
     },
     "required": ["title"]
 };
 
 instance = instantiator.instantiate(schema);
-// instance === { title: "Example", description: "" }
+// instance === { title: "Example", description: "", quantity: 0, endDate: "" }
 
 instance = instantiator.instantiate(schema, {requiredPropertiesOnly: false});
-// instance === { title: "Example", description: "" }
+// instance === { title: "Example", description: "", quantity: 0, endDate: "" }
 
 instance = instantiator.instantiate(schema, {requiredPropertiesOnly: true});
 // instance === { title: "Example" }
 
+// Override default values for a given type with a static value
+instance = instantiator.instantiate(schema, { defaults: { number: 42 } });
+// instance === { title: "Example", description: "", quantity: 42, endDate: "" }
+
+// Override default values for a given type function that returns a value
+instance = instantiator.instantiate(schema, {
+  defaults: {
+    // Function that receives current property/val and returns a value
+    string: function (val) {
+      var format = val.format;
+
+      if (format && format === "date") {
+        return new Date(2021, 0, 1);
+      }
+
+      return "";
+    },
+  },
+});
+// instance === { title: "Example", description: "", quantity: 0, endDate: new Date(2021, 0, 1) }
 ```
 
 ### AngularJS

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "json-schema-instantiator",
-  "version": "0.4.8",
+  "version": "0.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "json-schema-instantiator",
-  "version": "0.4.8",
+  "version": "0.5.0",
   "description": "A simple instantiator for json schemas.",
   "main": "index.js",
   "scripts": {

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -297,6 +297,65 @@ describe('Options', function() {
     expect(result).to.deep.equal(expected);
   });
 
+  it('should instantiate object with provided defaults', function () {
+    schema = {
+      'type': 'object',
+      'properties': {
+        'title': {
+          'type': 'string',
+        },
+        'quantity': {
+          'type': 'number'
+        }
+      },
+      'required': ['title']
+    };
+    result = instantiate(schema, {
+      defaults: {
+        string: 'foo',
+        number: 21
+      }
+    });
+    expected = {
+      'title': 'foo',
+      'quantity': 21,
+    };
+    expect(result).to.deep.equal(expected);
+  });
+
+  it('should instantiate object with provided function defaults', function () {
+    schema = {
+      'type': 'object',
+      'properties': {
+        'title': {
+          'type': 'string',
+        },
+        'birthday': {
+          'type': 'string',
+          'format': 'date'
+        },
+      },
+      'required': ['start']
+    };
+    result = instantiate(schema, {
+      defaults: {
+        string: function (val) {
+          var format = val.format;
+
+          if (format && format === 'date') {
+            return new Date(2021, 0, 1);
+          }
+
+          return '';
+        },
+      }
+    });
+    expected = {
+      'title': '',
+      'birthday': new Date(2021, 0, 1)
+    };
+    expect(result).to.deep.equal(expected);
+  });
 });
 
 describe('References', function() {


### PR DESCRIPTION
Add support for custom global default overrides/options. The idea is to be able to provide something like a date object for a `type: string` with a [date format](https://json-schema.org/understanding-json-schema/reference/string.html#dates-and-times). Options property `options.defaults` is a object keyed by type with a value of either a static value or a function that takes in `val` (to do conditional checks or similar) and returns a value.

Another option could be allowing `default` in the JSON schema to be either a static value or a function. That would make the schema not technically valid, but would allow property specific custom, dynamic default value generation.

Otherwise this could possibly be expanded to support constraints like [range](https://json-schema.org/understanding-json-schema/reference/numeric.html#id7) for numeric values.