### PR TITLE
Fix typescript importing in ESM

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "types": "dist/types/instantiator.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/types/instantiator.d.ts",
       "import": "./dist/esm/instantiator.mjs",
       "require": "./dist/cjs/instantiator.js"
     }


### PR DESCRIPTION
Could not find a declaration file for module 'json-schema-instantiator'. 'node_modules/json-schema-instantiator/dist/esm/instantiator.mjs' implicitly has an 'any' type.
  There are types at 'node_modules/json-schema-instantiator/dist/types/instantiator.d.ts', but this result could not be resolved when respecting package.json "exports". The 'json-schema-instantiator' library may need to update its package.json or typings.

See https://github.com/microsoft/TypeScript/issues/52363.